### PR TITLE
Make distribution "CPANTS clean"

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,8 @@ Revision history for Constant::Export::Lazy
     - Added COPYRIGHT AND LICENSE section to pod, with standard "as perl"
       boilerplate.
 
+    - Specified min perl version 5.6.0 in both code and metadata.
+
 0.11 2014-12-01 21:03:29
 
     - This release only has changes to make the test suite more

--- a/dist.ini
+++ b/dist.ini
@@ -9,6 +9,9 @@ dist          = Constant-Export-Lazy
 bugtracker    = rt
 no_AutoPrereq = 1
 
+[Prereqs]
+perl       = 5.006
+
 [Prereqs / TestRequires]
 Exporter   = 5.566
 Test::More = 0

--- a/lib/Constant/Export/Lazy.pm
+++ b/lib/Constant/Export/Lazy.pm
@@ -1,4 +1,5 @@
 package Constant::Export::Lazy;
+use 5.006;
 use strict;
 use warnings;
 


### PR DESCRIPTION
Hi Ævar,

These changes should make this dist CPANTS clean:
- License now specified in pod (matches the license type given in metadata)
- Specified min perl version as 5.6.0 in both code and metadata

Cheers,
Neil
